### PR TITLE
Load lockbox when attached from a directory containing a lockfile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lockbox
 Type: Package
 Title: lockbox (http://github.com/robertzk/lockbox)
 Description: Bundler-style dependency management for R.
-Version: 0.1.9.3
+Version: 0.1.9.4
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# Version 0.1.9.2-4
+
+  * Assorted fixes to library loading.
+
+  * When lockbox is attached to the search path while the current directory
+    is a project managed by lockbox (i.e., has a lockfile.yml somewhere in
+    a parent directory), the relevant package versions will be autoloaded.
+    This behavior can be disabled with `options(lockbox.autoload = FALSE)`.
+
 # Version 0.1.9.1
 
   * To be more consistent with `devtools`, you now have to set GITHUB_PAT

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,7 +75,7 @@ sanitize_transient_library <- function(...) {
 }
 
 .onAttach <- function(pkg, libPath) {
-  if (!isTRUE(getOption("lockbox.autoload", TRUE))) { 
+  if (isTRUE(getOption("lockbox.autoload", TRUE))) { 
     load_project()
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,7 +75,9 @@ sanitize_transient_library <- function(...) {
 }
 
 .onAttach <- function(pkg, libPath) {
-  load_project()
+  if (!isTRUE(getOption("lockbox.autoload", TRUE))) { 
+    load_project()
+  }
 }
 
 .onUnLoad <- function(pkg) {

--- a/README.md
+++ b/README.md
@@ -77,3 +77,15 @@ Example Lock File
   version: 0.1.4
   repo: privateorg/privatepkg
 ```
+
+Notes
+-----
+
+If you call `library(lockbox)` from within a directory that contains
+a `lockfile.yml` somewhere in a parent directory, that lockfile
+will be loaded and the relevant package versions attached to the 
+search path. In particular, you can place `library(lockbox)` in
+your `~/.Rprofile` and lockbox will be loaded if and only if
+you start your R session from a project that is managed by lockbox.
+
+This behavior can be disabled by setting `options(lockbox.autoload = FALSE)`.


### PR DESCRIPTION
If the current directory or its parents contain a `lockfile.yml`, attach the lockfile upon loading lockbox.
