### PR TITLE
Require the correct testthatsomemore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ LazyData: true
 Imports:
     yaml,
     digest,
-    testthatsomemore,
+    testthatsomemore (>= 0.2.4),
     devtools,
     utils
 Suggests:


### PR DESCRIPTION
Lockbox breaks on older versions (with an uncomprehensible error message no less!)
