### PR TITLE
Add autoinstall: true for quick development on local packages using lockbox, ft. bugfixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lockbox
 Type: Package
 Title: lockbox (http://github.com/robertzk/lockbox)
 Description: Bundler-style dependency management for R.
-Version: 0.1.12
+Version: 0.1.13
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,20 +8,17 @@ Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",
     email = "technoguyrob@gmail.com", role = c("aut", "cre")))
 Depends:
-    R (>= 3.0.1),
-    httr,
-    RCurl
+    R (>= 3.0.1)
 License: MIT
 LazyData: true
 Imports:
     yaml,
     digest,
-    testthatsomemore,
-    devtools,
-    utils
+    devtools
 Suggests:
     knitr,
     microbenchmark,
+    testthatsomemore,
     testthat
 Roxygen: list(wrap = FALSE)
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # Version 0.1.13
 
-  * Dev mode. NEWS TBD.
+  * Adds an option for `autoinstall: true` for quick development on local packages.
+  * Fixed the dependencies in the DESCRIPTION.
+  * Fixed the accidental suppression of package installation messages.
+  * Fixed typos in the announcements of packages being installed.
 
 # Version 0.1.12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.1.13
+
+  * Dev mode. NEWS TBD.
+
 # Version 0.1.12
 
   * Use a path for the staging library that is always available

--- a/R/library.R
+++ b/R/library.R
@@ -16,9 +16,6 @@
 #' @name ensure_package_exists_in_lockbox
 `ensure_package_exists_in_lockbox!` <- function(locked_package) {
   if (is.local_package(locked_package) && exists_in_lockbox(locked_package)) {
-    message(crayon::yellow(
-      paste0("Removing pre-existing local installation of ",
-        locked_package$name, "@", locked_package$version)))
     `remove_from_lockbox!`(locked_package)
   }
   if (!exists_in_lockbox(locked_package)) {
@@ -35,7 +32,9 @@ exists_in_lockbox <- function(locked_package) {
 }
 
 `remove_from_lockbox!` <- function(locked_package) {
-  file.remove(lockbox_package_path(locked_package))
+  message(crayon::yellow(paste0("Removing pre-existing local installation of ",
+    locked_package$name, "@", locked_package$version)))
+  unlink(lockbox_package_path(locked_package), recursive = TRUE, force = TRUE)
 }
 
 lockbox_package_path <- function(locked_package, library = lockbox_library()) {
@@ -56,8 +55,8 @@ lockbox_package_path <- function(locked_package, library = lockbox_library()) {
 }
 
 install_package <- function(locked_package) {
-  message("Installing", crayon::green(locked_package$name),
-      as.character(locked_package$version), "from", class(locked_package)[1], "\n")
+  message("Installing ", crayon::green(locked_package$name), " ",
+      as.character(locked_package$version), " from ", class(locked_package)[1], "\n")
   UseMethod("install_package")
 }
 

--- a/R/library.R
+++ b/R/library.R
@@ -15,13 +15,27 @@
 #'    does not exist.
 #' @name ensure_package_exists_in_lockbox
 `ensure_package_exists_in_lockbox!` <- function(locked_package) {
+  if (is.local_package(locked_package) && exists_in_lockbox(locked_package)) {
+    message(crayon::yellow(
+      paste0("Removing pre-existing local installation of ",
+        locked_package$name, "@", locked_package$version)))
+    `remove_from_lockbox!`(locked_package)
+  }
   if (!exists_in_lockbox(locked_package)) {
     `place_in_lockbox!`(locked_package)
   }
 }
 
+is.local_package <- function(locked_package) {
+  identical(locked_package$remote, "local")
+}
+
 exists_in_lockbox <- function(locked_package) {
   file.exists(lockbox_package_path(locked_package))
+}
+
+`remove_from_lockbox!` <- function(locked_package) {
+  file.remove(lockbox_package_path(locked_package))
 }
 
 lockbox_package_path <- function(locked_package, library = lockbox_library()) {
@@ -42,7 +56,7 @@ lockbox_package_path <- function(locked_package, library = lockbox_library()) {
 }
 
 install_package <- function(locked_package) {
-  cat("Installing", crayon::green(locked_package$name),
+  message("Installing", crayon::green(locked_package$name),
       as.character(locked_package$version), "from", class(locked_package)[1], "\n")
   UseMethod("install_package")
 }

--- a/R/library.R
+++ b/R/library.R
@@ -15,7 +15,7 @@
 #'    does not exist.
 #' @name ensure_package_exists_in_lockbox
 `ensure_package_exists_in_lockbox!` <- function(locked_package) {
-  if (is.local_package(locked_package) && exists_in_lockbox(locked_package)) {
+  if (should_remove_local(locked_package) && exists_in_lockbox(locked_package)) {
     `remove_from_lockbox!`(locked_package)
   }
   if (!exists_in_lockbox(locked_package)) {
@@ -25,6 +25,10 @@
 
 is.local_package <- function(locked_package) {
   identical(locked_package$remote, "local")
+}
+
+should_remove_local <- function(locked_package) {
+  is.local_package(locked_package) && isTRUE(locked_package$autoinstall)
 }
 
 exists_in_lockbox <- function(locked_package) {

--- a/R/lockbox.R
+++ b/R/lockbox.R
@@ -44,15 +44,17 @@ lockbox.list <- function(lock, env) {
   set_transient_library()
 
   ## Find the packages whose version does not match the current library.
+  local_packages <- vapply(lock, is.local_package, logical(1))
   mismatches <- vapply(lock, version_mismatch, logical(1))
+  reload_these_packages <- unlist(Map(any, mismatches, local_packages))
 
-  sapply(lock[!mismatches], function(locked_package) {
+  sapply(lock[!reload_these_packages], function(locked_package) {
     cat('Using', crayon::green(locked_package$name), as.character(locked_package$version), '\n')
   })
 
   quietly({
     ## Replace our library so that it has these packages instead.
-    align(lock[mismatches])
+    align(lock[reload_these_packages])
 
     ## And re-build our search path.
     rebuild(lock)

--- a/R/pending.R
+++ b/R/pending.R
@@ -1,0 +1,4 @@
+pending <- function() {
+  TRUE
+}
+

--- a/R/pending.R
+++ b/R/pending.R
@@ -1,4 +1,0 @@
-pending <- function() {
-  TRUE
-}
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,7 +59,7 @@ is.symlink <- function(path) {
 }
 
 quietly <- function(expr) {
-  suppressPackageStartupMessages(suppressMessages(suppressWarnings(expr)))
+  suppressPackageStartupMessages(suppressWarnings(expr))
 }
 
 package_version_from_path <- function(pkg_path) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -100,5 +100,3 @@ sanitize_transient_library <- function(...) {
     options(.lockbox_env$old_opts)
   }
 }
-
-

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Example Lock File
   remote: local
   dir: /your/pkg
 -
+  # Install a local package and re-install it every time your lockbox loads
+  # regardless of package verison, to make quick development possible.
+  name: yourpkg
+  version: 0.1.0
+  remote: local
+  dir: /your/pkg
+  autoinstall: true
+-
   # You can even install repos that are private on Github, as long as your
   # GIT_PAT environment variable is set (using your shell or, e.g., Sys.setenv)
   # to the value of your Github authorization token. To obtain one, see:


### PR DESCRIPTION
## Major Changes

**Adds an option for `autoinstall: true` for quick development on local packages.**

```
-
  # Install a local package and re-install it every time your lockbox loads
  # regardless of package verison, to make quick development possible.
  name: yourpkg
  version: 0.1.0
  remote: local
  dir: /your/pkg
  autoinstall: true
```

![](http://puu.sh/mvzPT/6b0dec097e.png)
## Bugfixes
- Fixed the dependencies in the DESCRIPTION.
- Fixed the accidental suppression of package installation messages.
- Fixed typos in the announcements of packages being installed.
