### PR TITLE
Fix regex to handle multiple remotes and be more flexible on CRAN's available packages filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lockbox
 Type: Package
 Title: lockbox (http://github.com/robertzk/lockbox)
 Description: Bundler-style dependency management for R.
-Version: 0.2.1
+Version: 0.2.2
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -361,7 +361,7 @@ dependencies_from_description <- function(package, dcf) {
 }
 
 get_non_remote_list <- function(dependencies_parsed) {
-  non_remote_dependencies <- dependencies_parsed[rownames(dependencies_parsed) != "Remotes", ]
+  non_remote_dependencies <- dependencies_parsed[!grepl("^Remotes", rownames(dependencies_parsed)), ]
 
   ## Remove the Depends entry that just corresponds to the R version requirements
   non_remote_dependencies <- non_remote_dependencies[!grepl("^[rR]$"
@@ -377,7 +377,7 @@ get_non_remote_list <- function(dependencies_parsed) {
 }
 
 get_remote_list <- function(dependencies_parsed) {
-  remote_dependencies <- dependencies_parsed[rownames(dependencies_parsed) == "Remotes", ]
+  remote_dependencies <- dependencies_parsed[grepl("^Remotes", rownames(dependencies_parsed)), ]
 
   ## Parse the remote dependencies into a list of packages
   if (identical(NROW(remote_dependencies),0L)){

--- a/R/library.R
+++ b/R/library.R
@@ -236,14 +236,14 @@ get_download_type <- function(package) {
 ## Return the latest available version of a package from CRAN
 get_available_cran_version <- function(package, repo = "http://cran.r-project.org") {
   type <- get_download_type(package)
-  available <- available.packages(contriburl = contrib.url(repos = repo)
-    , type = type, filter = c("OS_type", "subarch", "duplicates"))
+  available <- available.packages(contriburl = contrib.url(repos = repo, type = type)
+    , filter = c("OS_type", "subarch", "duplicates"))
   available <- data.frame(unique(available[, c("Package", "Version")]))
 
   ## If package is only available in source redo this call
   if (!package$name %in% available$Package && type != "source") {
-    available <- available.packages(contriburl = contrib.url(repos = repo)
-    , type = "source", filter = c("OS_type", "subarch", "duplicates"))
+    available <- available.packages(contriburl = contrib.url(repos = repo, type = "source")
+    , filter = c("OS_type", "subarch", "duplicates"))
     available <- data.frame(unique(available[, c("Package", "Version")]))
   }
   if (!package$name %in% available$Package) {


### PR DESCRIPTION
Remotes parsing had to be ever-so-slightly tweaked.
Available packages should be more friendly to different R versions now.  Figured I should tack that little change on since we're updating.
