### PR TITLE
Show parent

### DIFF
--- a/R/library.R
+++ b/R/library.R
@@ -294,8 +294,12 @@ get_available_cran_version <- function(package, repo = "http://cran.r-project.or
   }
   if (!package$name %in% available$Package) {
     prefix <- "Locked"
-    if (package$is_dependency_package) prefix <- "Dependency"
-    stop(paste0(prefix, " Package ", package$name, " is not available on CRAN."
+    parent_string <- ""
+    if (package$is_dependency_package) {
+      prefix <- "Dependency"
+      parent_string <- paste0(" from parent package ", package$parent_package)
+    }
+    stop(paste0(prefix, " Package ", package$name, parent_string, " is not available on CRAN."
       , " Do you need to specify this package's repo?"))
   }
   pkg <- available[available$Package == package$name, ]

--- a/R/library.R
+++ b/R/library.R
@@ -46,7 +46,7 @@ lockbox_package_download_path <- function(locked_package, library = lockbox_libr
   file.path(lockbox_download_dir(), locked_package$name
     , paste0(
       as.character(locked_package$remote %||% "CRAN")
-      , strsplit(locked_package$repo, "/")[[1]]
+      , paste(strsplit(locked_package$repo %||% "", "/")[[1]], collapse = "-")
       , as.character(locked_package$ref %||% locked_package$version)
       , get_extension(locked_package)))
 }


### PR DESCRIPTION
Addresses https://github.com/robertzk/lockbox/issues/93

Already had been saving parent package data to each package object, so this was easy.
Tested by breaking things:

![image](https://cloud.githubusercontent.com/assets/14277363/15221207/5936cae0-181f-11e6-8423-e1e2882796a2.png)
