### PR TITLE
Fix for latest_version of locked packages

### DIFF
--- a/R/library.R
+++ b/R/library.R
@@ -90,11 +90,13 @@ install_package.CRAN <- function(locked_package, libPath, quiet) {
 
   ## Last chance at installation if compilation fails.  Install through normal
   ## CRAN channels
-  if (!file.exists(pkgdir) &&
-    package_version(locked_package$version) == package_version(locked_package$latest_version)) {
-    repos <- getOption('lockbox.CRAN_mirror') %||% c(CRAN = "http://cran.r-project.org")
-    install.packages(locked_package$name, repos = repos
-      , type = get_download_type(locked_package), lib = libPath, quiet = quiet)
+  if (!file.exists(pkgdir)) {
+    locked_package$latest_version <- locked_package$latest_version %||% get_latest_version(locked_package)
+    if (package_version(locked_package$version) == package_version(locked_package$latest_version)) {
+      repos <- getOption('lockbox.CRAN_mirror') %||% c(CRAN = "http://cran.r-project.org")
+      install.packages(locked_package$name, repos = repos
+        , type = get_download_type(locked_package), lib = libPath, quiet = quiet)
+    }
   }
 }
 


### PR DESCRIPTION
Sometimes locked packages can fail due to compilation issues (lookin at gfortran, yo).  This is just an additional safeguard that assigns the latest version to the locked package when an install fails (previously latest versions were only assigned to dependency packages when a local version hadn't been downloaded yet).  That way we can try to install the binary when a locked package fails and the locked version we want is the same as the most recent CRAN version.  Only applies to CRAN packages and only when locked into the latest version.  It'd be nice if they archived binaries, but it is wut it is.
