### PR TITLE
Lockfiles must start with packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,53 +37,54 @@ Example Lock File
 
 ```yml
 # lockfile.yml in the project you wish to dependency manage using lockbox
--
-  # This will install the tundra package from github's robertzk/tundra repo
-  # off tag 0.2.2. You can specify a different tag / branch / ref using:
-  #   ref: v0.2.2 # For example
-  name: tundra
-  version: 0.2.2
-  repo: robertzk/tundra
--
-  name: director
-  version: 0.2.1
-  repo: robertzk/director
-  load: false # This package will not be loaded by default. The user must
-              # request it by calling library(director). In that case,
-              # the correct version (0.2.1) will be loaded.
--
-  # Use the kselection package version 0.2.0 from CRAN.
-  # If this is not the current version, the CRAN archive will be used.
-  name: kselection
-  version: 0.2.0
--
-  # Install a local (development) package version 0.1.0 from directory
-  # /your/pkg. Using this approach is not recommended, since you will
-  # not be able to keep your lock file under version control and shareable
-  # with other contributors to the project, as they are unlikely to have
-  # the same package / version in the same directory. However, it is useful
-  # for development prior to pushing a new version to, e.g., github.
-  name: yourpkg
-  version: 0.1.0
-  dir: /your/pkg
--
-  # Install a local package and re-install it every time your lockbox loads
-  # regardless of package version, to make quick development possible.
-  # ...Keep in mind that the contents of autoinstalled packages are only
-  # *loaded*, and not re-saved to lockbox each time...
-  name: yourpkg
-  version: 0.1.0
-  dir: /your/pkg
-  autoinstall: true
--
-  # You can even install repos that are private on Github, as long as your
-  # GIT_PAT environment variable is set (using your shell or, e.g., Sys.setenv)
-  # to the value of your Github authorization token. To obtain one, see:
-  #   https://help.github.com/articles/creating-an-access-token-for-command-line-use/
-  # It should be a 32-character hexadecimal string.
-  name: privatepkg
-  version: 0.1.4
-  repo: privateorg/privatepkg
+packages:
+  -
+    # This will install the tundra package from github's robertzk/tundra repo
+    # off tag 0.2.2. You can specify a different tag / branch / ref using:
+    #   ref: v0.2.2 # For example
+    name: tundra
+    version: 0.2.2
+    repo: robertzk/tundra
+  -
+    name: director
+    version: 0.2.1
+    repo: robertzk/director
+    load: false # This package will not be loaded by default. The user must
+                # request it by calling library(director). In that case,
+                # the correct version (0.2.1) will be loaded.
+  -
+    # Use the kselection package version 0.2.0 from CRAN.
+    # If this is not the current version, the CRAN archive will be used.
+    name: kselection
+    version: 0.2.0
+  -
+    # Install a local (development) package version 0.1.0 from directory
+    # /your/pkg. Using this approach is not recommended, since you will
+    # not be able to keep your lock file under version control and shareable
+    # with other contributors to the project, as they are unlikely to have
+    # the same package / version in the same directory. However, it is useful
+    # for development prior to pushing a new version to, e.g., github.
+    name: yourpkg
+    version: 0.1.0
+    dir: /your/pkg
+  -
+    # Install a local package and re-install it every time your lockbox loads
+    # regardless of package version, to make quick development possible.
+    # ...Keep in mind that the contents of autoinstalled packages are only
+    # *loaded*, and not re-saved to lockbox each time...
+    name: yourpkg
+    version: 0.1.0
+    dir: /your/pkg
+    autoinstall: true
+  -
+    # You can even install repos that are private on Github, as long as your
+    # GIT_PAT environment variable is set (using your shell or, e.g., Sys.setenv)
+    # to the value of your Github authorization token. To obtain one, see:
+    #   https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+    # It should be a 32-character hexadecimal string.
+    name: privatepkg
+    version: 0.1.4
+    repo: privateorg/privatepkg
 ```
 
 Notes


### PR DESCRIPTION
Otherwise `Invalid config. Make sure your config format is correct` is encountered.
