### PR TITLE
Explicitly reference methods::is throughout.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lockbox
 Type: Package
 Title: lockbox (http://github.com/robertzk/lockbox)
 Description: Bundler-style dependency management for R.
-Version: 0.2.4.5
+Version: 0.2.4.6
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Version 0.2.4.6
+
+  * Explicitly reference `methods::is`.
+
+# Version 0.2.4.5 
+
+  * Add session identifiers to staging library.
+
 # Version 0.2.4.4
 
   * Remove unnecessary package exports (`setNames`, `packageVersion`, `untar`).

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -206,7 +206,7 @@ get_dependencies <- function(package, lock) {
   } else {
     cat(crayon_blue("."))
     output <- tryCatch(get_remote_dependencies(package), error = function(e) e)
-    if (is(output, "error")) {
+    if (methods::is(output, "error")) {
       stop(crayon_red(paste0("Dependencies could not be resolved for package: "
         , package$name, " version: ", package$version
         , " remote: ", package$remote, " due to error: ", output)))
@@ -306,7 +306,7 @@ download_description_github <- function(package) {
     class = c(remote, class(package))))
   package$download_path <- filepath
   file_list <- try(unzip(filepath, list = TRUE))
-  if (is(file_list, "try-error")) {
+  if (methods::is(file_list, "try-error")) {
     filepath <- download_package(structure(
       package,
       class = c(remote, class(package))), force = TRUE)

--- a/R/library.R
+++ b/R/library.R
@@ -150,7 +150,7 @@ install_locked_package <- function(locked_package) {
     , error = function(e) e)
 
   ## If we have an error during installation try again and show everything
-  if (is(output, "error") || !file.exists(pkgdir)) {
+  if (methods::is(output, "error") || !file.exists(pkgdir)) {
     try(install_package(locked_package, temp_library, FALSE))
     unlink(temp_library, TRUE, TRUE)
     stop("Must have installed the package ",
@@ -250,7 +250,7 @@ download_package.CRAN <- function(package, force) {
 
   ## Sometimes the current version isn't accessible in it's usual place,
   ## but is already archived
-  if (is(out, "error")) {
+  if (methods::is(out, "error")) {
     archive_addition <- paste0("Archive/", name, "/")
     from <- paste0(repo, "/src/contrib/", archive_addition, name, "_"
       , ref %||% version , ".tar.gz")

--- a/R/lockbox.R
+++ b/R/lockbox.R
@@ -118,7 +118,7 @@ as.locked_package <- function(list) {
   structure(list, class = "locked_package")
 }
 
-is.locked_package <- function(obj) is(obj, "locked_package")
+is.locked_package <- function(obj) { methods::is(obj, "locked_package") }
 
 #' The secret lockbox library path.
 lockbox_library <- function() {


### PR DESCRIPTION
Should resolve [this issue](https://github.com/robertzk/lockbox/issues/112).