### PR TITLE
Tarball remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lockbox
 Type: Package
 Title: lockbox (http://github.com/robertzk/lockbox)
 Description: Bundler-style dependency management for R.
-Version: 0.2.5.1
+Version: 0.2.5.2
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.2.5.2
+
+  * Support `tarball` remote in `lockfile.yml`.
+
 # Version 0.2.5.1
 
   * Version numbers with two digits (e.g., "0.2") are now cast as character.

--- a/R/library.R
+++ b/R/library.R
@@ -81,6 +81,13 @@ install_package.local <- function(locked_package, libPath, quiet) {
     , type = "source", quiet = quiet)
 }
 
+install_package.tarball <- function(locked_package, libPath, quiet) {
+  stopifnot(is.element("url", names(locked_package)))
+
+  utils::install.packages(locked_package$url, lib = libPath, repos = NULL
+    , quiet = quiet)
+}
+
 install_package.CRAN <- function(locked_package, libPath, quiet) {
   ## We already downloaded a source file when parsing DESCRIPTIONS, so try that
   ## first
@@ -270,6 +277,20 @@ download_package.github <- function(package, force) {
   }
   remote <- get_remote(package)
   remote_download.github_remote(remote, dest, quiet = !isTRUE(getOption('lockbox.verbose')))
+}
+
+## download a raw tarball from a URL
+download_package.tarball <- function(package, force) {
+  dest <- lockbox_package_download_path(package)
+  if (is.na(package$version)) {
+    package$version <- NULL
+  }
+
+  suppressWarnings(tryCatch(
+    download.file(url = package$url, destfile = lockbox_package_download_path(package)
+    , quiet = notTRUE(getOption('lockbox.verbose'))), error = function(e) e))
+
+  dest
 }
 
 get_download_type <- function(package) {

--- a/R/library.R
+++ b/R/library.R
@@ -84,7 +84,7 @@ install_package.local <- function(locked_package, libPath, quiet) {
 install_package.tarball <- function(locked_package, libPath, quiet) {
   ## First, attempt to install the already downloaded tarball
   try(utils::install.packages(locked_package$download_path, lib = libPath
-    , repos = NULL, type = "source", quiet = quiet))
+    , repos = NULL, type = "source", quiet = quiet), silent = TRUE)
   pkgdir <- file.path(libPath, locked_package$name)
 
   ## If that didn't work out, attempt to download directly from URL
@@ -99,7 +99,7 @@ install_package.CRAN <- function(locked_package, libPath, quiet) {
   ## We already downloaded a source file when parsing DESCRIPTIONS, so try that
   ## first
   try(utils::install.packages(locked_package$download_path, lib = libPath
-    , repos = NULL, type = "source", quiet = quiet))
+    , repos = NULL, type = "source", quiet = quiet), silent = TRUE)
   pkgdir <- file.path(libPath, locked_package$name)
 
   ## Last chance at installation if compilation fails.  Install through normal

--- a/R/library.R
+++ b/R/library.R
@@ -82,10 +82,17 @@ install_package.local <- function(locked_package, libPath, quiet) {
 }
 
 install_package.tarball <- function(locked_package, libPath, quiet) {
-  stopifnot(is.element("url", names(locked_package)))
+  ## First, attempt to install the already downloaded tarball
+  try(utils::install.packages(locked_package$download_path, lib = libPath
+    , repos = NULL, type = "source", quiet = quiet))
+  pkgdir <- file.path(libPath, locked_package$name)
 
-  utils::install.packages(locked_package$url, lib = libPath, repos = NULL
-    , quiet = quiet)
+  ## If that didn't work out, attempt to download directly from URL
+  if (!file.exists(pkgdir)) {
+    stopifnot(is.element("url", names(locked_package)))
+    utils::install.packages(locked_package$url, lib = libPath, repos = NULL
+      , quiet = quiet)
+  }
 }
 
 install_package.CRAN <- function(locked_package, libPath, quiet) {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ lockbox::lockbox("lockfile.yml")
 
 Your search path will be cleared of all other loaded packages, ensuring you
 have exactly and only what is in the lockfile. If you place the above line
-in the `.Rprofile` accompanying your project directory and keep the 
+in the `.Rprofile` accompanying your project directory and keep the
 `lockfile.yml` under source control, launching the R console after
 switching to earlier commits will instantly load your old dependencies,
 forever freeing you from having to worry about dependency management.
@@ -34,7 +34,7 @@ devtools::install_github("robertzk/lockbox")
 Real examples
 ------------
 
-* [A very simple lockfile](https://github.com/syberia/base.sy/blob/master/lockfile.yml) 
+* [A very simple lockfile](https://github.com/syberia/base.sy/blob/master/lockfile.yml)
 * [A more complicated lockfile](https://github.com/syberia/example.sy/blob/master/lockfile.yml)
 
 Example Lock File
@@ -90,6 +90,13 @@ packages:
     name: privatepkg
     version: 0.1.4
     repo: privateorg/privatepkg
+  -
+    # You can install packages directly from a file hosting server or AWS S3
+    # If they are distributed in a form of a CRAN-compatible tarball
+    name: tarballpkg
+    version: 3.2.2
+    remote: tarball
+    url: https://example.org/tarball.tar.gz
 ```
 
 Notes
@@ -97,7 +104,7 @@ Notes
 
 If you call `library(lockbox)` from within a directory that contains
 a `lockfile.yml` somewhere in a parent directory, that lockfile
-will be loaded and the relevant package versions attached to the 
+will be loaded and the relevant package versions attached to the
 search path. In particular, you can place `library(lockbox)` in
 your `~/.Rprofile` and lockbox will be loaded if and only if
 you start your R session from a project that is managed by lockbox.

--- a/tests/testthat/data/test-readme-example.yml
+++ b/tests/testthat/data/test-readme-example.yml
@@ -24,3 +24,8 @@ packages:
     name: privatepkg
     version: 0.1.4
     repo: privateorg/privatepkg
+  -
+    name: tarballpkg
+    version: 3.2.2
+    remote: tarball
+    url: https://example.org/tarball.tar.gz

--- a/tests/testthat/test-parse-lock.R
+++ b/tests/testthat/test-parse-lock.R
@@ -99,7 +99,7 @@ describe("it can read envs from a yaml", {
     })
 
     test_that("it can handle versions with more than one digit", {
-      expect_equal(parsed_lock[[2]]$version, "0.999") 
+      expect_equal(parsed_lock[[2]]$version, "0.999")
     })
   })
   describe("prod env", {
@@ -133,4 +133,5 @@ test_that("it loads the example from the README", {
   expect_is(parsed_lock[[5]]$version, "character")
   expect_is(parsed_lock[[5]]$autoinstall, "logical")
   expect_equal(names(parsed_lock[[6]]), c("name", "version", "repo"))
+  expect_equal(names(parsed_lock[[7]]), c("name", "version", "remote", "url"))
 })


### PR DESCRIPTION
Support things like

```yml
-
    name: xgboost
    remote: tarball
    url: "http://dmlc.ml/drat/src/contrib/xgboost_0.6.4.6.tar.gz"
    version: 0.6.4.6
```